### PR TITLE
Add backtest service to StockTradeService

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vcpkg"]
 	path = thirdparties/vcpkg
 	url = https://github.com/CasinoHe/vcpkg.git
+[submodule "talib"]
+	path = thirdparties/ta-lib
+	url = https://github.com/CasinoHe/ta-lib.git

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -50,6 +50,10 @@ list(REMOVE_ITEM LUA_SOURCES ${LUA_ROOT}/lua.c ${LUA_ROOT}/onelua.c)
 include_directories(${LUA_ROOT})
 # --------------------- build lua end ---------------------------
 
+# --------------------- build ta-lib start ---------------------------
+include(${SERVER_ROOT_DIR}/TALib.cmake)
+# --------------------- build ta-lib end ---------------------------
+
 # --------------------- build tws api start ---------------------------
 set(TWS_ROOT "${THIRDPARTY_DIR}/tws")
 file(GLOB TWS_SOURCES ${TWS_ROOT}/*.cpp)
@@ -62,7 +66,7 @@ source_group("lua" FILES ${LUA_SOURCES})
 source_group("tws" FILES ${TWS_SOURCES} ${TWS_HEADERS})
 source_group("server" FILES ${SERVER_SOURCES})
 
-add_executable(${PROJECT_NAME} ${SERVER_SOURCES} ${LUA_SOURCES} ${TWS_SOURCES})
+add_executable(${PROJECT_NAME} ${SERVER_SOURCES} ${LUA_SOURCES} ${TWS_SOURCES} ${TA_LIB_SOURCES})
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${THIRDPARTY_DIR}/fmt/include
                                                   ${THIRDPARTY_DIR}/spdlog/include

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -40,7 +40,7 @@ set(THIRDPARTY_DIR ${PROJECT_ROOT_DIR}/thirdparties)
 # the dependencies is built by vcpkg or custom build
 find_package(fmt 11.0.2 REQUIRED)
 find_package(spdlog 1.15.0 REQUIRED)
-find_package(Boost 1.86.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.86.0 REQUIRED COMPONENTS program_options algorithm)
 find_package(unofficial-concurrentqueue CONFIG REQUIRED)
 
 # --------------------- build lua start ---------------------------
@@ -79,6 +79,7 @@ target_link_directories(${PROJECT_NAME} PRIVATE ${THIRD_PARTY_LIB_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE fmt::fmt 
                                 spdlog::spdlog
                                 Boost::program_options
+                                Boost::algorithm
                                 intel_decimal128
                                 unofficial::concurrentqueue::concurrentqueue
                                 )

--- a/server/TALib.cmake
+++ b/server/TALib.cmake
@@ -1,0 +1,90 @@
+set(TA_LIB_ROOT_DIR "${THIRDPARTY_DIR}/ta-lib")
+
+set(TA_LIB_VERSION_MAJOR 0)
+set(TA_LIB_VERSION_MINOR 6)
+set(TA_LIB_VERSION_PATCH 4)
+
+set(TA_LIB_VERSION "${TA_LIB_VERSION_MAJOR}.${TA_LIB_VERSION_MINOR}.${TA_LIB_VERSION_PATCH}")
+
+# Default to Release config
+if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+endif()
+
+message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
+
+# Source used in all end-user libraries and most TA-Lib executable.
+file(GLOB TA_LIB_COMMON_SOURCES "${TA_LIB_ROOT_DIR}/src/ta_common/*.c")
+
+# TA-Lib specify all its TA functions signature (and meta information
+# such as the "group" it belongs to) using an "interface definition language"
+# written in C.
+file(GLOB_RECURSE TA_LIB_ABSTRACT_SOURCES "${TA_LIB_ROOT_DIR}/src/ta_abstract/*.c")
+
+###############################
+# static libraries #
+###############################
+include(CheckIncludeFiles)
+include(CheckFunctionExists)
+include(CheckTypeSize)
+include(CheckSymbolExists)
+check_include_files(float.h HAVE_FLOAT_H)
+check_include_files(inttypes.h HAVE_INTTYPES_H)
+check_include_files(limits.h HAVE_LIMITS_H)
+check_include_files(locale.h HAVE_LOCALE_H)
+check_include_files(stddef.h HAVE_STDDEF_H)
+check_include_files(stdint.h HAVE_STDINT_H)
+check_include_files(stdlib.h HAVE_STDLIB_H)
+check_include_files(string.h HAVE_STRING_H)
+check_include_files(unistd.h HAVE_UNISTD_H)
+check_include_files(wchar.h HAVE_WCHAR_H)
+check_include_files(wctype.h HAVE_WCTYPE_H)
+check_function_exists(floor HAVE_FLOOR)
+check_function_exists(isascii HAVE_ISASCII)
+check_function_exists(localeconv HAVE_LOCALECONV)
+check_function_exists(mblen HAVE_MBLEN)
+check_function_exists(memmove HAVE_MEMMOVE)
+check_function_exists(memset HAVE_MEMSET)
+check_function_exists(modf HAVE_MODF)
+check_function_exists(pow HAVE_POW)
+check_function_exists(sqrt HAVE_SQRT)
+check_function_exists(strcasecmp HAVE_STRCASECMP)
+check_function_exists(strchr HAVE_STRCHR)
+check_function_exists(strerror HAVE_STRERROR)
+check_function_exists(strncasecmp HAVE_STRNCASECMP)
+check_function_exists(strrchr HAVE_STRRCHR)
+check_function_exists(strstr HAVE_STRSTR)
+check_function_exists(strtol HAVE_STRTOL)
+check_function_exists(strtoul HAVE_STRTOUL)
+check_function_exists(strcoll HAVE_STRCOLL)
+check_function_exists(strftime HAVE_STRFTIME)
+check_function_exists(vprintf HAVE_VPRINTF)
+check_type_size(ptrdiff_t SIZEOF_PTRDIFF_T)
+if(HAVE_SIZEOF_PTRDIFF_T)
+	set(HAVE_PTRDIFF_T 1)
+else()
+	set(HAVE_PTRDIFF_T 0)
+endif()
+check_type_size(size_t SIZEOF_SIZE_T)
+if(HAVE_SIZEOF_SIZE_T)
+	set(HAVE_SIZE_T 1)
+else()
+	set(HAVE_SIZE_T 0)
+	set(size_t "unsigned")
+endif()
+check_symbol_exists("struct tm" "sys/time.h" TM_IN_SYS_TIME)
+configure_file("${TA_LIB_ROOT_DIR}/include/ta_config.h.cmake" "${TA_LIB_ROOT_DIR}/include/ta_config.h")
+
+include_directories(
+	"${TA_LIB_ROOT_DIR}/include"
+	"${TA_LIB_ROOT_DIR}/src/ta_abstract"
+	"${TA_LIB_ROOT_DIR}/src/ta_abstract/frames"
+	"${TA_LIB_ROOT_DIR}/src/ta_common"
+	"${TA_LIB_ROOT_DIR}/src/ta_func"
+)
+
+# TA-Lib functions implementation.
+file(GLOB TA_LIB_FUNC_SOURCES ${TA_LIB_ROOT_DIR}/src/ta_func/*.c)
+
+set(TA_LIB_SOURCES ${TA_LIB_COMMON_SOURCES} ${TA_LIB_ABSTRACT_SOURCES} ${TA_LIB_FUNC_SOURCES})

--- a/server/broker/requests.h
+++ b/server/broker/requests.h
@@ -7,10 +7,13 @@
 namespace quanttrader {
 namespace broker {
 
+// -----------------------------  Request -------------------------------------------
 enum class RequestType {
     NO_REQUEST = 0,
     REQUEST_CURRENT_TIME = 1,
-    ERROR_MSG = 2,
+    REQUEST_HISTORICAL_DATA = 2,
+    ERROR_MSG = 999,
+    END_REQUEST = 1000,
 };
 
 struct RequestHeader {
@@ -28,6 +31,29 @@ struct ReqCurrentTime : RequestHeader {
         request_type = RequestType::REQUEST_CURRENT_TIME;
     }
 };
+
+struct ReqHistoricalData: RequestHeader {
+    ReqHistoricalData() {
+        request_type = RequestType::REQUEST_HISTORICAL_DATA;
+    }
+
+    std::string symbol = "AAPL";
+    std::string security_type = "STK";
+    std::string currency = "USD";
+    std::string exchange = "SMART";
+    std::string duration = "1 D";
+    std::string bar_size = "30 S";
+    std::string what_to_show = "TRADES";
+    bool use_rth = true;
+    bool format_date = false;
+    std::string end_time = "20220101 00:00:00";
+    bool keep_up_to_date = false;
+};
+
+// ----------------------------------------------------------------------------------
+
+
+// -----------------------------  Response -------------------------------------------
 struct ResCurrentTime : ResponseHeader {
     long time;
     ResCurrentTime() {
@@ -45,6 +71,8 @@ struct ResErrorMsg : ResponseHeader {
         response_type = RequestType::ERROR_MSG;
     }
 };
+
+// ----------------------------------------------------------------------------------
 
 }
 }

--- a/server/script/config_sample.lua
+++ b/server/script/config_sample.lua
@@ -6,7 +6,7 @@ tws_service = {
 	clientid = 0,
 
 	retry_interval = 5000,  -- retry interval in milliseconds
-	wait_timeout = 10,      -- wait data from TWS timeout in milliseconds
+	wait_timeout = 10,      -- wait data from TWS timeout in milliseconds, not updated unless restart quanttrader, TODO
 	update_config_interval = 60000, -- update config interval in milliseconds
 	record_log = 0,         -- record log or not
 	stop_flag = 0,          -- stop flag
@@ -19,5 +19,19 @@ stock_trade_service = {
 }
 
 back_test_service = {
-	wait_new_strategy_interval = 1000,
+	update_config_interval = 60000,
+	wait_timeout = 1000,                   -- timeout on each threads in back test loop in milliseconds
+	new_test = "apple_daily,msft_weekly",  -- config table name, split by comma
+	-- restart_test = "apple_daily,msft_weekly", -- which test to restart
+	-- stop_test = "apple_daily,msft_weekly",  -- which test to stop
+}
+
+apple_daily = {
+	version = 1,
+
+}
+
+msft_weekly = {
+	version = 1,
+
 }

--- a/server/script/config_sample.lua
+++ b/server/script/config_sample.lua
@@ -28,7 +28,11 @@ back_test_service = {
 
 apple_daily = {
 	version = 1,
-
+	strategy_name = "slope_strategy",
+	symbol = "AAPL",
+	start_date = "2016-01-01 00:00:00",
+	end_date = "2024-12-31 23:59:59",
+	timezone = "America/New_York",
 }
 
 msft_weekly = {

--- a/server/script/config_sample.lua
+++ b/server/script/config_sample.lua
@@ -15,4 +15,9 @@ tws_service = {
 stock_trade_service = {
 	broker_service = "tws",
 	broker_config = "this",
+	back_test_config = "this",
+}
+
+back_test_service = {
+	wait_new_strategy_interval = 1000,
 }

--- a/server/service/back_test_service.cpp
+++ b/server/service/back_test_service.cpp
@@ -1,0 +1,112 @@
+#include "back_test_service.h"
+#include "tws_service.h"
+#include "broker/requests.h"
+#include "ta_libc.h"
+
+namespace quanttrader {
+namespace service {
+
+BackTestService::BackTestService(const std::string_view config_path) : ServiceBase<BackTestService>("back_test_service") {
+    logger_ = quanttrader::log::get_common_rotation_logger("BackTestService", "service", false);
+
+    if (!set_config_path(config_path)) {
+        logger_->error("Cannot set the configuration file path: {}, please check the existence of the file and the config file should be a regular lua file.", config_path);
+    } else {
+        logger_->info("BackTestService instance created with config file: {}", config_path);
+    }
+}
+
+bool BackTestService::prepare() {
+    bool result = ServiceBase<BackTestService>::prepare();
+    if (!result) {
+        logger_->error("Cannot load configuration file: {}. Please check the existence of the file or try to run the file.", get_config_path());
+        return false;
+    }
+
+    // Load additional configuration specific to back testing
+    std::string historical_data_path = get_string_value("historical_data_path");
+    if (historical_data_path.empty()) {
+        logger_->error("Cannot find the historical data path in the configuration file.");
+        return false;
+    }
+
+    // Initialize TwsService
+    std::string tws_config = get_string_value("tws_config");
+    if (tws_config == "this") {
+        tws_config = get_config_path();
+    }
+
+    tws_service_ = quanttrader::service::ServiceFactory::get_service<quanttrader::service::TwsService>(tws_config);
+    if (!tws_service_->prepare()) {
+        logger_->error("Cannot prepare the TwsService. Please check the service.log file for more information.");
+        return false;
+    }
+
+    response_queue_ = std::make_shared<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>>();
+    tws_service_->set_response_queue(response_queue_);
+
+    logger_->info("BackTestService prepared with historical data path: {}", historical_data_path);
+    return true;
+}
+
+void BackTestService::run() {
+    if (!is_service_prepared()) {
+        logger_->error("Service is not prepared. Please prepare the service first.");
+        return;
+    }
+
+    logger_->info("BackTestService is running...");
+
+    // Request historical data from TwsService
+    auto request_id = quanttrader::broker::TwsClient::next_request_id();
+    quanttrader::broker::Contract contract;
+    contract.symbol = "AAPL";
+    contract.secType = "STK";
+    contract.currency = "USD";
+    contract.exchange = "SMART";
+
+    tws_service_->push_request(std::make_shared<quanttrader::broker::ReqHistoricalData>(request_id, contract, "20220101 00:00:00", "1 M", "1 day", "TRADES", 1));
+
+    // Process responses
+    std::shared_ptr<broker::ResponseHeader> response;
+    while (response_queue_->wait_dequeue_timed(response, std::chrono::milliseconds(100))) {
+        if (response->response_type == broker::ResponseType::HISTORICAL_DATA) {
+            auto historical_data = std::dynamic_pointer_cast<broker::ResHistoricalData>(response);
+            logger_->info("Received historical data: Date: {}, Open: {}, High: {}, Low: {}, Close: {}, Volume: {}",
+                          historical_data->bar.time, historical_data->bar.open, historical_data->bar.high,
+                          historical_data->bar.low, historical_data->bar.close, historical_data->bar.volume);
+
+            // Use ta-lib indicators for back testing logic
+            TA_Initialize();
+            TA_Real close_prices[historical_data->bars.size()];
+            for (size_t i = 0; i < historical_data->bars.size(); ++i) {
+                close_prices[i] = historical_data->bars[i].close;
+            }
+
+            TA_Integer outBeg, outNbElement;
+            TA_Real outRSI[historical_data->bars.size()];
+            TA_RetCode retCode = TA_RSI(0, historical_data->bars.size() - 1, close_prices, 14, &outBeg, &outNbElement, outRSI);
+
+            if (retCode == TA_SUCCESS) {
+                for (int i = 0; i < outNbElement; ++i) {
+                    logger_->info("RSI: {}", outRSI[i]);
+                }
+            } else {
+                logger_->error("Error calculating RSI: {}", retCode);
+            }
+
+            TA_Shutdown();
+        }
+    }
+
+    logger_->info("BackTestService has completed running.");
+}
+
+void BackTestService::stop() {
+    logger_->info("BackTestService is stopping...");
+    // Implement any cleanup or stopping logic here
+    logger_->info("BackTestService has stopped.");
+}
+
+}
+}

--- a/server/service/back_test_service.cpp
+++ b/server/service/back_test_service.cpp
@@ -2,6 +2,8 @@
 #include "tws_service.h"
 #include "broker/requests.h"
 #include "ta_libc.h"
+#include "service/service_consts.h"
+#include <boost/algorithm/string.hpp>
 
 namespace quanttrader {
 namespace service {
@@ -41,14 +43,9 @@ void BackTestService::run() {
     }
 
     logger_->info("Start BackTestService...");
-    // start update config thread
 
+    // start update config thread
     std::thread read_config_thread(&BackTestService::update_config, this);
-    uint64_t wait_interval = get_int_value("wait_new_strategy_interval");
-    if (wait_interval == 0) {
-        wait_interval = 1000;
-    }
-    std::chrono::milliseconds wait_time(wait_interval);
 
     while (true) {
         if (stop_flag_.load()) {
@@ -56,10 +53,10 @@ void BackTestService::run() {
         }
 
         // check if there is a back testing request
-        for (auto &back_test : back_test_threads_) {
+        for (auto &back_test : back_test_process_) {
         }
 
-        std::this_thread::sleep_for(wait_time);
+        std::this_thread::sleep_for(wait_timeout_);
     }
 
     if (read_config_thread.joinable()) {
@@ -79,7 +76,105 @@ void BackTestService::run_back_test() {
 }
 
 void BackTestService::update_config() {
+    auto update_time = std::chrono::system_clock::now();
 
+    while(true) {
+        if (stop_flag_.load()) {
+            logger_->info("Stop flag is set, exit the update config thread.");
+            break;
+        }
+
+        auto cur = std::chrono::system_clock::now();
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(cur - update_time) > update_config_interval_) {
+            update_time = cur;
+            set_reload_config();
+            if (!load_config()) {
+                logger_->error("Cannot update the configuration file.");
+                std::this_thread::sleep_for(update_config_interval_);
+                continue;
+            } else {
+                // update the interval to reload the configuration file
+                uint64_t wait_interval = get_int_value(UPDATE_CONFIG_INTERVAL_VARIABLE);
+                if (wait_interval != 0) {
+                    update_config_interval_ = std::chrono::milliseconds(wait_interval);
+                }
+                uint64_t wait_timeout = get_int_value(WAIT_TIMEOUT_VARIABLE);
+                if (wait_timeout != 0) {
+                    wait_timeout_ = std::chrono::milliseconds(wait_timeout);
+                }
+
+                // handle the data change in back test
+                handle_need_stop_process();
+                handle_need_start_process();
+                handle_need_restarting_process();
+
+                logger_->info("Reloaded config.");
+            }
+        }
+
+        std::this_thread::sleep_for(wait_timeout_);
+    }
+}
+
+void BackTestService::handle_need_stop_process() {
+    // stop back test process in the column "stop_test" in the configuration file
+    std::string need_stop_process = get_string_value("stop_test");
+    if (need_stop_process.empty()) {
+        return;
+    }
+
+    // process key name is split by comma
+    std::vector<std::string> process_keys;
+    boost::split(process_keys, need_stop_process, boost::is_any_of(","));
+
+    for (auto &key : process_keys) {
+        // update process data
+
+        // get the data, compare the version, if the version is the same, skip the process because it is already manipulated 
+        int version = get_int_value_in_table(key, "version");
+        if (version <= 0) {
+            logger_->warn("Cannot find the version for the process: {} version {}", key, version);
+            continue;
+        }
+
+        // manipulating the back_test_process_ map should be protected by mutex
+        std::lock_guard<std::mutex> lock(back_test_process_mutex_);
+        
+        // find the process in the back_test_process_ list
+        auto it = back_test_process_.find(key);
+        if (it != back_test_process_.end()) {
+            // stop the process
+            if (it->second) {
+                // compare the version
+                if (it->second->version != version) {
+                    // tag the need stop process
+                    it->second->expected_state = BackTestState::STOPPED;
+                    it->second->version = version;
+                    logger_->info("The process {} is tagged to stop, version {}.", key, version);
+                }
+            } else {
+                logger_->warn("The process need to stop {} is not running.", key);
+            }
+        } else {
+            logger_->warn("Cannot find the process which need to be stopped: {}", key);
+        }
+    }
+}
+
+void BackTestService::handle_need_start_process() {
+    // start back test process in the column "new_test" in the configuration file
+    std::string need_start_process = get_string_value("new_test");
+
+}
+
+void BackTestService::handle_need_restarting_process() {
+    // restart back test process in the column "restart_test" in the configuration file
+    std::string need_restart_process = get_string_value("restart_test");
+}
+
+void BackTestService::update_process_data(const std::string_view key) {
+    // update the process data in the back_test_process_ list
+    // TODO:
 }
 
 }

--- a/server/service/back_test_service.cpp
+++ b/server/service/back_test_service.cpp
@@ -7,7 +7,7 @@ namespace quanttrader {
 namespace service {
 
 BackTestService::BackTestService(const std::string_view config_path) : ServiceBase<BackTestService>("back_test_service") {
-    logger_ = quanttrader::log::get_common_rotation_logger("BackTestService", "service", false);
+    logger_ = quanttrader::log::get_common_rotation_logger("BackTest", "service", false);
 
     if (!set_config_path(config_path)) {
         logger_->error("Cannot set the configuration file path: {}, please check the existence of the file and the config file should be a regular lua file.", config_path);
@@ -30,21 +30,6 @@ bool BackTestService::prepare() {
         return false;
     }
 
-    // Initialize TwsService
-    std::string tws_config = get_string_value("tws_config");
-    if (tws_config == "this") {
-        tws_config = get_config_path();
-    }
-
-    tws_service_ = quanttrader::service::ServiceFactory::get_service<quanttrader::service::TwsService>(tws_config);
-    if (!tws_service_->prepare()) {
-        logger_->error("Cannot prepare the TwsService. Please check the service.log file for more information.");
-        return false;
-    }
-
-    response_queue_ = std::make_shared<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>>();
-    tws_service_->set_response_queue(response_queue_);
-
     logger_->info("BackTestService prepared with historical data path: {}", historical_data_path);
     return true;
 }
@@ -55,57 +40,46 @@ void BackTestService::run() {
         return;
     }
 
-    logger_->info("BackTestService is running...");
+    logger_->info("Start BackTestService...");
+    // start update config thread
 
-    // Request historical data from TwsService
-    auto request_id = quanttrader::broker::TwsClient::next_request_id();
-    quanttrader::broker::Contract contract;
-    contract.symbol = "AAPL";
-    contract.secType = "STK";
-    contract.currency = "USD";
-    contract.exchange = "SMART";
+    std::thread read_config_thread(&BackTestService::update_config, this);
+    uint64_t wait_interval = get_int_value("wait_new_strategy_interval");
+    if (wait_interval == 0) {
+        wait_interval = 1000;
+    }
+    std::chrono::milliseconds wait_time(wait_interval);
 
-    tws_service_->push_request(std::make_shared<quanttrader::broker::ReqHistoricalData>(request_id, contract, "20220101 00:00:00", "1 M", "1 day", "TRADES", 1));
-
-    // Process responses
-    std::shared_ptr<broker::ResponseHeader> response;
-    while (response_queue_->wait_dequeue_timed(response, std::chrono::milliseconds(100))) {
-        if (response->response_type == broker::ResponseType::HISTORICAL_DATA) {
-            auto historical_data = std::dynamic_pointer_cast<broker::ResHistoricalData>(response);
-            logger_->info("Received historical data: Date: {}, Open: {}, High: {}, Low: {}, Close: {}, Volume: {}",
-                          historical_data->bar.time, historical_data->bar.open, historical_data->bar.high,
-                          historical_data->bar.low, historical_data->bar.close, historical_data->bar.volume);
-
-            // Use ta-lib indicators for back testing logic
-            TA_Initialize();
-            TA_Real close_prices[historical_data->bars.size()];
-            for (size_t i = 0; i < historical_data->bars.size(); ++i) {
-                close_prices[i] = historical_data->bars[i].close;
-            }
-
-            TA_Integer outBeg, outNbElement;
-            TA_Real outRSI[historical_data->bars.size()];
-            TA_RetCode retCode = TA_RSI(0, historical_data->bars.size() - 1, close_prices, 14, &outBeg, &outNbElement, outRSI);
-
-            if (retCode == TA_SUCCESS) {
-                for (int i = 0; i < outNbElement; ++i) {
-                    logger_->info("RSI: {}", outRSI[i]);
-                }
-            } else {
-                logger_->error("Error calculating RSI: {}", retCode);
-            }
-
-            TA_Shutdown();
+    while (true) {
+        if (stop_flag_.load()) {
+            break;
         }
+
+        // check if there is a back testing request
+        for (auto &back_test : back_test_threads_) {
+        }
+
+        std::this_thread::sleep_for(wait_time);
+    }
+
+    if (read_config_thread.joinable()) {
+        read_config_thread.join();
     }
 
     logger_->info("BackTestService has completed running.");
 }
 
 void BackTestService::stop() {
-    logger_->info("BackTestService is stopping...");
-    // Implement any cleanup or stopping logic here
-    logger_->info("BackTestService has stopped.");
+    stop_flag_.store(true);
+    logger_->info("Set stop flag");
+}
+
+void BackTestService::run_back_test() {
+
+}
+
+void BackTestService::update_config() {
+
 }
 
 }

--- a/server/service/back_test_service.h
+++ b/server/service/back_test_service.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "service.h"
+#include "logger/quantlogger.h"
+#include "concurrentqueue/blockingconcurrentqueue.h"
+#include "tws_service.h"
+
+namespace quanttrader {
+namespace service {
+
+class BackTestService : public ServiceBase<BackTestService> {
+public:
+    bool prepare() override;
+    void run() override;
+    void stop() override;
+
+private:
+    friend class Singleton<BackTestService>;
+    BackTestService(const std::string_view config_path);
+    ~BackTestService() = default;
+
+    quanttrader::log::LoggerPtr logger_ {nullptr};
+    std::string config_path_;
+    std::shared_ptr<TwsService> tws_service_ {nullptr};
+    std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue_ {nullptr};
+};
+
+}
+}

--- a/server/service/back_test_service.h
+++ b/server/service/back_test_service.h
@@ -37,6 +37,7 @@ struct BackTestStruct {
     std::string symbol;
     std::string start_date;
     std::string end_date;
+    std::string time_zone;
     std::shared_ptr<std::thread> process;
 };
 

--- a/server/service/back_test_service.h
+++ b/server/service/back_test_service.h
@@ -3,10 +3,29 @@
 #include "service.h"
 #include "logger/quantlogger.h"
 #include "concurrentqueue/blockingconcurrentqueue.h"
-#include "tws_service.h"
+#include <memory>
+#include <unordered_map>
+#include <tuple>
+#include <thread>
+#include <atomic>
+#include <mutex>
 
 namespace quanttrader {
+
+namespace broker {
+struct RequestHeader;
+struct ResponseHeader;
+}
+
 namespace service {
+
+enum class BackTestState {
+    INIT = 0,
+    WAIT_STARTING = 1,
+    RUNNING = 2,
+    WAIT_STOPPING = 3,
+    STOPPED = 4,
+};
 
 class BackTestService : public ServiceBase<BackTestService> {
 public:
@@ -14,15 +33,24 @@ public:
     void run() override;
     void stop() override;
 
+    void set_response_queue(std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue) { response_queue_ = response_queue; };
+    void set_request_queue(std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::RequestHeader>>> request_queue) { request_queue_ = request_queue; }
+
 private:
     friend class Singleton<BackTestService>;
     BackTestService(const std::string_view config_path);
     ~BackTestService() = default;
 
+    void run_back_test();
+    void update_config();
+
+private:
+    std::atomic<bool> stop_flag_ {false};
     quanttrader::log::LoggerPtr logger_ {nullptr};
-    std::string config_path_;
-    std::shared_ptr<TwsService> tws_service_ {nullptr};
+    std::string config_path_ {};
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue_ {nullptr};
+    std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::RequestHeader>>> request_queue_ = nullptr;
+    std::unordered_map<std::string, std::tuple<BackTestState, std::shared_ptr<std::thread>>> back_test_threads_;
 };
 
 }

--- a/server/service/service.h
+++ b/server/service/service.h
@@ -65,6 +65,22 @@ public:
         return lua_config_->get_string_value(service_name_, key);
     }
 
+    int get_int_value_in_table(const std::string &table_name, const std::string &key) {
+        if (!config_loaded_) {
+            throw std::runtime_error("Service is not prepared. Please prepare the service first.");
+        }
+
+        return lua_config_->get_int_value(table_name, key);
+    }
+
+    std::string get_string_value_in_table(const std::string &table_name, const std::string &key) {
+        if (!config_loaded_) {
+            throw std::runtime_error("Service is not prepared. Please prepare the service first.");
+        }
+
+        return lua_config_->get_string_value(table_name, key);
+    }
+
     // Run the service
     virtual bool prepare() { return load_config(); }
     virtual void run() = 0;

--- a/server/service/service_consts.h
+++ b/server/service/service_consts.h
@@ -1,0 +1,16 @@
+#pragma once
+
+constexpr char UPDATE_CONFIG_INTERVAL_VARIABLE[] = "update_config_interval";
+constexpr char HOST_VARIABLE[] = "host";
+constexpr char PORT_VARIABLE[] = "port";
+constexpr char CLIENTID_VARIABLE[] = "clientid";
+constexpr char RETRY_INTERVAL_VARIABLE[] = "retry_interval";
+constexpr char WAIT_TIMEOUT_VARIABLE[] = "wait_timeout";
+constexpr char RECORD_LOG_VARIABLE[] = "record_log";
+constexpr char VERSION_VARIABLE[] = "version";
+constexpr char STOP_FLAG_VARIABLE[] = "stop_flag";
+
+constexpr int kDefaultUpdateConfigInterval = 60000;  // interval to update the configuration file in milliseconds
+constexpr int kDefaultRetryInterval = 5000;          // retry interval to connect to TWS in milliseconds
+constexpr int kDefaultWaitTimeout = 10;              // wait timeout in milliseconds in each thread in broker service
+constexpr int kDefaultWaitBackTestTimeout = 1000;    // wait timeout in milliseconds in back test service

--- a/server/service/service_consts.h
+++ b/server/service/service_consts.h
@@ -9,6 +9,16 @@ constexpr char WAIT_TIMEOUT_VARIABLE[] = "wait_timeout";
 constexpr char RECORD_LOG_VARIABLE[] = "record_log";
 constexpr char VERSION_VARIABLE[] = "version";
 constexpr char STOP_FLAG_VARIABLE[] = "stop_flag";
+constexpr char STOP_BACK_TEST_VARIABLE[] = "stop_test";
+constexpr char START_BACK_TEST_VARIABLE[] = "new_test";
+constexpr char SPLIT_BACK_TEST_VARIABLE[] = ",";
+
+// strategy variables
+constexpr char STRATEGY_NAME_VARIABLE[] = "strategy_name";
+constexpr char SYMBOL_VARIABLE[] = "symbol";
+constexpr char START_DATE_VARIABLE[] = "start_date";
+constexpr char END_DATE_VARIABLE[] = "end_date";
+constexpr char TIME_ZONE_VARIABLE[] = "time_zone";
 
 constexpr int kDefaultUpdateConfigInterval = 60000;  // interval to update the configuration file in milliseconds
 constexpr int kDefaultRetryInterval = 5000;          // retry interval to connect to TWS in milliseconds

--- a/server/service/stock_trade_service.h
+++ b/server/service/stock_trade_service.h
@@ -33,6 +33,7 @@ private:
     quanttrader::log::LoggerPtr logger_ {nullptr};
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue_ {nullptr};
     std::shared_ptr<void> broker_service_ {nullptr};  // broker service, defined by configuration file
+    std::shared_ptr<void> back_test_service_ {nullptr};  // back test service, defined by configuration file
 };
 
 }

--- a/server/service/stock_trade_service.h
+++ b/server/service/stock_trade_service.h
@@ -31,6 +31,7 @@ private:
 
 private:
     quanttrader::log::LoggerPtr logger_ {nullptr};
+    std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::RequestHeader>>> request_queue_ {nullptr};
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue_ {nullptr};
     std::shared_ptr<void> broker_service_ {nullptr};  // broker service, defined by configuration file
     std::shared_ptr<void> back_test_service_ {nullptr};  // back test service, defined by configuration file

--- a/server/service/tws_service.cpp
+++ b/server/service/tws_service.cpp
@@ -1,6 +1,7 @@
 #include "service/tws_service.h"
 #include "broker/twsclient.h"
 #include "broker/requests.h"
+#include "service/service_consts.h"
 
 #include <chrono>
 
@@ -227,12 +228,12 @@ bool TwsService::prepare() {
     }
 
     // Get config information from config file
-    int port = get_int_value("port");
-    std::string ip = get_string_value("host");
-    int clientid = get_int_value("clientid");
-    int retry_interval = get_int_value("retry_interval");
-    int wait_timeout = get_int_value("wait_timeout");
-    int update_config_interval = get_int_value("update_config_interval");
+    int port = get_int_value(PORT_VARIABLE);
+    std::string ip = get_string_value(HOST_VARIABLE);
+    int clientid = get_int_value(CLIENTID_VARIABLE);
+    int retry_interval = get_int_value(RETRY_INTERVAL_VARIABLE);
+    int wait_timeout = get_int_value(WAIT_TIMEOUT_VARIABLE);
+    int update_config_interval = get_int_value(UPDATE_CONFIG_INTERVAL_VARIABLE);
 
     if (retry_interval > 0) {
         retry_interval_ = std::chrono::milliseconds(retry_interval);
@@ -268,16 +269,16 @@ bool TwsService::update_config(std::atomic<int> &tws_version) {
     bool modified = false;
 
     // Get config information from config file
-    int port = get_int_value("port");
-    std::string ip = get_string_value("host");
-    int clientid = get_int_value("clientid");
-    int retry_interval = get_int_value("retry_interval");
-    int wait_timeout = get_int_value("wait_timeout");
-    int update_config_interval = get_int_value("update_config_interval");
-    int record_log = get_int_value("record_log");
-    int version = get_int_value("version");
+    int port = get_int_value(PORT_VARIABLE);
+    std::string ip = get_string_value(HOST_VARIABLE);
+    int clientid = get_int_value(CLIENTID_VARIABLE);
+    int retry_interval = get_int_value(RETRY_INTERVAL_VARIABLE);
+    int wait_timeout = get_int_value(WAIT_TIMEOUT_VARIABLE);
+    int update_config_interval = get_int_value(UPDATE_CONFIG_INTERVAL_VARIABLE);
+    int record_log = get_int_value(RECORD_LOG_VARIABLE);
+    int version = get_int_value(VERSION_VARIABLE);
     // TODO: use signal to stop rather than set stop in config file
-    int stop_flag = get_int_value("stop_flag");
+    int stop_flag = get_int_value(STOP_FLAG_VARIABLE);
 
     const std::string_view old_ip = client_->get_host();
     const int old_port = client_->get_port();

--- a/server/service/tws_service.cpp
+++ b/server/service/tws_service.cpp
@@ -9,7 +9,7 @@ namespace quanttrader {
 namespace service {
 
 TwsService::TwsService(const std::string_view config_path) : ServiceBase<TwsService>("tws_service") {
-    logger_ = quanttrader::log::get_common_rotation_logger("TwsService", "service", false);
+    logger_ = quanttrader::log::get_common_rotation_logger("Tws", "service", false);
 
     if (!set_config_path(config_path)) {
         logger_->error("Cannot set the configuration file path: {}, please check the existence of the file and the config file should be a regular lua file.", config_path);
@@ -331,7 +331,6 @@ bool TwsService::update_config(std::atomic<int> &tws_version) {
 
 void TwsService::init_after_connected() {
     // start the threads
-    request_queue_ = std::make_shared<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::RequestHeader>>>();
     error_queue_ = std::make_shared<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResErrorMsg>>>();
     client_->set_response_queue(response_queue_);
     client_->set_error_queue(error_queue_);

--- a/server/service/tws_service.h
+++ b/server/service/tws_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "service.h"
+#include "service/service.h"
+#include "service/service_consts.h"
 #include "logger/quantlogger.h"
 #include "concurrentqueue/blockingconcurrentqueue.h"
 #include <string>
@@ -63,9 +64,9 @@ private:
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::RequestHeader>>> request_queue_ = nullptr;
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue_ = nullptr;
     std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResErrorMsg>>> error_queue_{nullptr};
-    std::chrono::milliseconds retry_interval_{5000};
-    std::chrono::milliseconds wait_timeout_{10};
-    std::chrono::milliseconds update_config_interval_{60000};
+    std::chrono::milliseconds retry_interval_{kDefaultRetryInterval};
+    std::chrono::milliseconds wait_timeout_{kDefaultWaitTimeout};
+    std::chrono::milliseconds update_config_interval_{kDefaultUpdateConfigInterval};
 };
 
 }

--- a/server/service/tws_service.h
+++ b/server/service/tws_service.h
@@ -30,6 +30,9 @@ public:
     void set_response_queue(std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::ResponseHeader>>> response_queue) {
         response_queue_ = response_queue;
     }
+    void set_request_queue(std::shared_ptr<moodycamel::BlockingConcurrentQueue<std::shared_ptr<broker::RequestHeader>>> request_queue) {
+        request_queue_ = request_queue;
+    }
 
 private:
     friend class Singleton<TwsService>;

--- a/server/vcpkg.json
+++ b/server/vcpkg.json
@@ -15,6 +15,10 @@
             "features": []
         },
         {
+            "name": "boost-algorithm",
+            "features": []
+        },
+        {
             "name": "intelrdfpmathlib",
             "features": []
         },


### PR DESCRIPTION
Add `BackTestService` to the project and integrate it with `StockTradeService`.

* **Add `BackTestService`**:
  - Create `back_test_service.h` and `back_test_service.cpp` files.
  - Define `BackTestService` class with `prepare`, `run`, and `stop` methods.
  - Implement `prepare` method to load configuration and initialize `TwsService`.
  - Implement `run` method to request ticker data from `TwsService` and process responses using ta-lib indicators.
  - Implement `stop` method for cleanup.

* **Modify `StockTradeService`**:
  - Update `stock_trade_service.h` to include a private member variable for `BackTestService`.
  - Modify `run` method in `stock_trade_service.cpp` to start both `TwsService` and `BackTestService`.
  - Add logic to prepare and run `BackTestService` in `stock_trade_service.cpp`.

