### PR TITLE
Fix missing first bar in DataResampler

### DIFF
--- a/server/data/resampler/data_resampler.cpp
+++ b/server/data/resampler/data_resampler.cpp
@@ -109,6 +109,9 @@ bool DataResampler::start_request_data() {
                 resampled_bar.swap,
                 resampled_bar.count
             );
+
+            // Start aggregation for the current bar that triggered completion
+            add_to_aggregation(bar.value());
         }
     }
     


### PR DESCRIPTION
## Summary
- ensure resampler starts a new aggregation after emitting a bar

## Testing
- `python -m py_compile build_project.py`

------
https://chatgpt.com/codex/tasks/task_e_685b6ae617a0833187cfe7363b96d4f9