### PR TITLE
Fix crash due to unjoined thread in TwsBrokerAdapter

### DIFF
--- a/server/broker/tws/tws_broker_adapter.cpp
+++ b/server/broker/tws/tws_broker_adapter.cpp
@@ -14,6 +14,11 @@ TwsBrokerAdapter::TwsBrokerAdapter(const std::string_view configPath) : configPa
     logger_->info("TwsBrokerAdapter instance created with config file: {}", configPath);
 }
 
+TwsBrokerAdapter::~TwsBrokerAdapter() {
+    // Ensure background thread is properly terminated before destruction
+    stop();
+}
+
 // Implementation of BrokerProvider interface methods
 bool TwsBrokerAdapter::connect() {
     if (!client_) {

--- a/server/broker/tws/tws_broker_adapter.h
+++ b/server/broker/tws/tws_broker_adapter.h
@@ -90,7 +90,7 @@ public:
 private:
     friend class Singleton<TwsBrokerAdapter>;
     TwsBrokerAdapter(const std::string_view configPath);
-    ~TwsBrokerAdapter() = default;
+    ~TwsBrokerAdapter();
 
     // TWS client handling methods
     void runTws();


### PR DESCRIPTION
## Summary
- implement custom destructor for `TwsBrokerAdapter`
- ensure background thread is stopped before object destruction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68634a8bbc088331be69daa0a94138eb