### PR TITLE
Add observer base and refine performance metrics

### DIFF
--- a/server/cerebro/backtest/backtest_cerebro.h
+++ b/server/cerebro/backtest/backtest_cerebro.h
@@ -81,6 +81,9 @@ public:
         
         is_running_ = false;
         logger_->info("Backtest completed with {} steps", step_count);
+        for (auto& obs : observers_) {
+            obs->report();
+        }
         return true;
     }
 };

--- a/server/cerebro/cerebro_base.cpp
+++ b/server/cerebro/cerebro_base.cpp
@@ -4,10 +4,10 @@ namespace quanttrader {
 namespace cerebro {
 
 CerebroBase::CerebroBase(const std::string_view name) : name_(name), stop_flag_(false) {
-        logger_ = quanttrader::log::get_common_rotation_logger(name_, "cerebro");
-        logger_->info("Created cerebro: {} ", name_);
-    logger_ = quanttrader::log::get_common_rotation_logger("CerebroBase", "cerebro");
+    logger_ = quanttrader::log::get_common_rotation_logger(name_, "cerebro");
+    logger_->info("Created cerebro: {} ", name_);
     replay_controller_ = std::make_shared<data::replay::DataReplayController>();
+    observers_.push_back(std::make_shared<observer::PerformanceObserver>());
 }
 
 CerebroBase::~CerebroBase() {
@@ -47,6 +47,9 @@ bool CerebroBase::add_strategy(std::shared_ptr<strategy::StrategyBase> strategy)
     }
     
     strategies_.push_back(strategy);
+    for (auto& obs : observers_) {
+        strategy->add_observer(obs);
+    }
     logger_->info("{} Added strategy: {}", name_, strategy->get_name());
     return true;
 }
@@ -252,7 +255,20 @@ bool CerebroBase::process_next() {
     for (auto& strategy : strategies_) {
         strategy->on_data_series(cached_bar_series_);
     }
-    
+
+    std::map<std::string, double> price_map;
+    for (const auto& [name, bar] : sync_result.data) {
+        if (bar.has_value()) {
+            auto provider = replay_controller_->get_data_provider(name);
+            if (provider) {
+                price_map[provider->get_symbol()] = bar->close;
+            }
+        }
+    }
+    for (auto& obs : observers_) {
+        obs->update_market_value(sync_result.current_time, price_map);
+    }
+
     return true;
 }
 

--- a/server/cerebro/cerebro_base.h
+++ b/server/cerebro/cerebro_base.h
@@ -4,6 +4,8 @@
 #include "data/common/data_provider.h"
 #include "data/replay/data_replay_controller.h"
 #include "strategy/strategy_base.h"
+#include "observer/observer_base.h"
+#include "observer/performance_observer.h"
 #include "logger/quantlogger.h"
 #include <memory>
 #include <string>
@@ -107,6 +109,9 @@ public:
         wait_data_timeout_ = timeout;
     }
 
+    std::vector<std::shared_ptr<observer::ObserverBase>> get_observers() const { return observers_; }
+    void add_observer(std::shared_ptr<observer::ObserverBase> obs) { if (obs) observers_.push_back(obs); }
+
 protected:
     /**
      * @brief Update cached BarSeries with new bar data
@@ -149,6 +154,8 @@ protected:
     std::shared_ptr<broker::BrokerProvider> broker_;
     std::atomic<bool> stop_flag_;
     long long wait_data_timeout_ = 60000; // 60 seconds
+
+    std::vector<std::shared_ptr<observer::ObserverBase>> observers_;
 };
 
 } // namespace cerebro

--- a/server/data/common/data_struct.h
+++ b/server/data/common/data_struct.h
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <iomanip>
 #include <ctime>
+#include <cstring>
 #include <sstream>
 
 namespace quanttrader {

--- a/server/observer/observer_base.h
+++ b/server/observer/observer_base.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <cstdint>
+
+namespace quanttrader {
+namespace observer {
+
+class ObserverBase {
+public:
+    virtual ~ObserverBase() = default;
+
+    virtual void record_trade(uint64_t time,
+                              const std::string& symbol,
+                              int quantity,
+                              double price,
+                              bool is_buy) = 0;
+
+    virtual void update_market_value(uint64_t time,
+                                     const std::map<std::string, double>& prices) = 0;
+
+    virtual void report() const = 0;
+};
+
+} // namespace observer
+} // namespace quanttrader

--- a/server/observer/performance_observer.cpp
+++ b/server/observer/performance_observer.cpp
@@ -1,0 +1,109 @@
+#include "performance_observer.h"
+#include <iostream>
+
+namespace quanttrader {
+namespace observer {
+
+PerformanceObserver::PerformanceObserver(double starting_cash)
+    : starting_cash_(starting_cash), cash_(starting_cash), equity_(starting_cash),
+      peak_equity_(starting_cash), max_drawdown_(0.0) {
+    logger_ = quanttrader::log::get_common_rotation_logger("PerformanceObserver", "observer");
+}
+
+void PerformanceObserver::record_trade(uint64_t time, const std::string& symbol, int quantity, double price, bool is_buy) {
+    if (quantity <= 0)
+        return;
+
+    trades_.push_back({time, symbol, quantity, price, is_buy});
+
+    int signed_qty = is_buy ? quantity : -quantity;
+    int prev_qty = positions_[symbol];
+    int new_qty = prev_qty + signed_qty;
+
+    cash_ += is_buy ? -price * quantity : price * quantity;
+
+    if (prev_qty == 0 && new_qty != 0) {
+        // Opening a new position
+        avg_price_[symbol] = price;
+        open_trades_[symbol] = {time, symbol, quantity, new_qty > 0, price, price};
+    } else if ((prev_qty > 0 && new_qty == 0) || (prev_qty < 0 && new_qty == 0)) {
+        // Closing a position completely
+        bool was_long = prev_qty > 0;
+        double entry_price = avg_price_[symbol];
+        double profit = was_long ? (price - entry_price) * std::abs(prev_qty)
+                                : (entry_price - price) * std::abs(prev_qty);
+        if (profit >= 0)
+            gross_profit_ += profit;
+        else
+            gross_loss_ += -profit;
+
+        auto it_trade = open_trades_.find(symbol);
+        if (it_trade != open_trades_.end()) {
+            double dd = was_long ? (it_trade->second.entry_price - it_trade->second.worst_price)
+                                 : (it_trade->second.worst_price - it_trade->second.entry_price);
+            CompletedTrade ct{it_trade->second.entry_time, time, symbol, std::abs(prev_qty), was_long,
+                              it_trade->second.entry_price, price, dd * std::abs(prev_qty), profit,
+                              time - it_trade->second.entry_time};
+            completed_trades_.push_back(ct);
+            open_trades_.erase(it_trade);
+        }
+
+        avg_price_.erase(symbol);
+    } else if (prev_qty != 0 && ((prev_qty > 0) == (new_qty > 0))) {
+        // Increasing existing position in same direction
+        double prev_cost = avg_price_[symbol] * std::abs(prev_qty);
+        avg_price_[symbol] = (prev_cost + price * quantity) / std::abs(new_qty);
+    }
+
+    positions_[symbol] = new_qty;
+}
+
+void PerformanceObserver::update_market_value(uint64_t /*time*/, const std::map<std::string, double>& prices) {
+    double pos_value = 0.0;
+    for (const auto& [symbol, qty] : positions_) {
+        auto it = prices.find(symbol);
+        if (it != prices.end()) {
+            pos_value += qty * it->second;
+            auto it_trade = open_trades_.find(symbol);
+            if (it_trade != open_trades_.end()) {
+                if (it_trade->second.is_long) {
+                    if (it->second < it_trade->second.worst_price) {
+                        it_trade->second.worst_price = it->second;
+                    }
+                } else {
+                    if (it->second > it_trade->second.worst_price) {
+                        it_trade->second.worst_price = it->second;
+                    }
+                }
+            }
+        }
+    }
+
+    equity_ = cash_ + pos_value;
+    if (equity_ > peak_equity_) {
+        peak_equity_ = equity_;
+    } else {
+        double dd = peak_equity_ - equity_;
+        if (dd > max_drawdown_) {
+            max_drawdown_ = dd;
+        }
+    }
+}
+
+void PerformanceObserver::report() const {
+    logger_->info("===== Performance Report =====");
+    logger_->info("Starting cash: {}", starting_cash_);
+    logger_->info("Ending equity: {}", equity_);
+    logger_->info("Total profit: {}", equity_ - starting_cash_);
+    logger_->info("Gross profit: {}", gross_profit_);
+    logger_->info("Gross loss: {}", gross_loss_);
+    logger_->info("Max drawdown: {}", max_drawdown_);
+    for (const auto& ct : completed_trades_) {
+        logger_->info("Trade {} {} {}->{} qty {} profit {:.2f} dd {:.2f} duration {}",
+                      ct.symbol, ct.is_long ? "LONG" : "SHORT", ct.entry_price, ct.exit_price,
+                      ct.quantity, ct.profit, ct.max_drawdown, ct.duration);
+    }
+}
+
+} // namespace observer
+} // namespace quanttrader

--- a/server/observer/performance_observer.h
+++ b/server/observer/performance_observer.h
@@ -43,6 +43,7 @@ struct OpenTrade {
 class PerformanceObserver : public ObserverBase {
 public:
     explicit PerformanceObserver(double starting_cash = 100000.0);
+    ~PerformanceObserver() override = default;
 
     void record_trade(uint64_t time, const std::string& symbol, int quantity, double price, bool is_buy) override;
 

--- a/server/observer/performance_observer.h
+++ b/server/observer/performance_observer.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "observer_base.h"
+#include "logger/quantlogger.h"
+#include <map>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace quanttrader {
+namespace observer {
+
+struct TradeRecord {
+    uint64_t time;
+    std::string symbol;
+    int quantity;
+    double price;
+    bool is_buy;
+};
+
+struct CompletedTrade {
+    uint64_t entry_time;
+    uint64_t exit_time;
+    std::string symbol;
+    int quantity;
+    bool is_long;
+    double entry_price;
+    double exit_price;
+    double max_drawdown;
+    double profit;
+    uint64_t duration;
+};
+
+struct OpenTrade {
+    uint64_t entry_time;
+    std::string symbol;
+    int quantity;
+    bool is_long;
+    double entry_price;
+    double worst_price;
+};
+
+class PerformanceObserver : public ObserverBase {
+public:
+    explicit PerformanceObserver(double starting_cash = 100000.0);
+
+    void record_trade(uint64_t time, const std::string& symbol, int quantity, double price, bool is_buy) override;
+
+    void update_market_value(uint64_t time, const std::map<std::string, double>& prices) override;
+
+    double get_equity() const { return equity_; }
+    double get_max_drawdown() const { return max_drawdown_; }
+    double get_gross_profit() const { return gross_profit_; }
+    double get_gross_loss() const { return gross_loss_; }
+
+    void report() const override;
+
+private:
+    double starting_cash_;
+    double cash_;
+    double equity_;
+    double peak_equity_;
+    double max_drawdown_;
+    double gross_profit_ = 0.0;
+    double gross_loss_ = 0.0;
+    std::map<std::string, int> positions_;
+    std::map<std::string, double> avg_price_;
+    std::vector<TradeRecord> trades_;
+    std::map<std::string, OpenTrade> open_trades_;
+    std::vector<CompletedTrade> completed_trades_;
+    quanttrader::log::LoggerPtr logger_;
+};
+
+} // namespace observer
+} // namespace quanttrader

--- a/server/strategy/strategy_base.h
+++ b/server/strategy/strategy_base.h
@@ -7,8 +7,10 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <vector>
 #include "logger/quantlogger.h"
 #include "data/common/data_struct.h"
+#include "observer/observer_base.h"
 
 namespace quanttrader {
 namespace data {
@@ -53,6 +55,8 @@ public:
     virtual bool initialize();
     virtual bool on_start();
     virtual bool on_stop();
+
+    void add_observer(std::shared_ptr<observer::ObserverBase> obs) { if (obs) observers_.push_back(obs); }
     
     // Access methods
     std::string get_name() const { return strategy_name_; }
@@ -72,6 +76,10 @@ protected:
 
     // key data debug switch
     bool log_data_ = false; // Added key data debug switch
+
+    std::vector<std::shared_ptr<observer::ObserverBase>> observers_;
+    uint64_t current_time_ = 0;
+    std::unordered_map<std::string, double> last_prices_;
 
     // Derived strategies should implement this method
     virtual void next() = 0;


### PR DESCRIPTION
## Summary
- introduce `ObserverBase` for a pluggable observer hierarchy
- allow strategies and the cerebro engine to manage multiple observers
- fix max drawdown tracking using lowest/highest prices while a trade is open
- store completed trade details such as profit and drawdown

## Testing
- `g++ -std=c++20 -c server/observer/performance_observer.cpp -I server -I server/basic -I thirdparties -I thirdparties/fmt/include -I thirdparties/spdlog/include` *(fails: spdlog/spdlog.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bada62888833186e9e8a60f2c0a01